### PR TITLE
Redirect to story detail after creation

### DIFF
--- a/taletinker/stories/templates/stories/story_detail.html
+++ b/taletinker/stories/templates/stories/story_detail.html
@@ -1,0 +1,7 @@
+{% extends "base.html" %}
+{% block title %}Story Detail{% endblock %}
+{% block content %}
+<h2>{{ story.texts.first.title }}</h2>
+<p>{{ story.texts.first.text }}</p>
+<a href="{% url 'create_story' %}">Create another story</a>
+{% endblock %}

--- a/taletinker/stories/tests.py
+++ b/taletinker/stories/tests.py
@@ -40,6 +40,24 @@ class CreateStoryViewTests(TestCase):
         self.assertEqual(story.parameters["realism"], 50)
         self.assertEqual(story.texts.first().text, "Once upon a time")
 
+    def test_post_redirects_to_detail(self):
+        self.client.force_login(self.user)
+        data = {
+            "realism": 50,
+            "didactic": 50,
+            "age": 5,
+            "themes": ["family"],
+            "purposes": ["joyful"],
+            "characters": "Jane",
+            "extra_instructions": "A test story.",
+            "story_length": "short",
+            "language": "en",
+            "story_text": "Once upon a time",
+        }
+        response = self.client.post(reverse("create_story"), data)
+        story = Story.objects.first()
+        self.assertRedirects(response, reverse("story_detail", args=[story.id]))
+
 
 class NinjaCreateApiTests(TestCase):
     def setUp(self):

--- a/taletinker/stories/views.py
+++ b/taletinker/stories/views.py
@@ -1,5 +1,5 @@
 from django.contrib.auth.decorators import login_required
-from django.shortcuts import redirect, render
+from django.shortcuts import redirect, render, get_object_or_404
 
 from .forms import StoryCreationForm
 from .models import Story, StoryText
@@ -32,7 +32,12 @@ def create_story(request):
                     title=text.splitlines()[0][:255] if text.strip() else "Story",
                     text=text,
                 )
-            return redirect("create_story")
+            return redirect("story_detail", story_id=story.id)
     else:
         form = StoryCreationForm()
     return render(request, "stories/create_story.html", {"form": form})
+
+
+def story_detail(request, story_id: int):
+    story = get_object_or_404(Story, pk=story_id)
+    return render(request, "stories/story_detail.html", {"story": story})

--- a/taletinker/urls.py
+++ b/taletinker/urls.py
@@ -19,7 +19,7 @@ from django.contrib.auth import views as auth_views
 from django.http import HttpResponseRedirect
 from django.urls import path
 
-from taletinker.stories.views import create_story
+from taletinker.stories.views import create_story, story_detail
 from taletinker.accounts.views import LogoutView
 from taletinker.api import api as ninja_api
 
@@ -28,6 +28,7 @@ urlpatterns = [
     path('login/', auth_views.LoginView.as_view(), name='login'),
     path('logout/', LogoutView.as_view(), name='logout'),
     path('create/', create_story, name='create_story'),
+    path('story/<int:story_id>/', story_detail, name='story_detail'),
     path('api/', ninja_api.urls),
     path('', lambda request: HttpResponseRedirect('/create/')),
 ]


### PR DESCRIPTION
## Summary
- redirect create_story view to new story_detail page
- add story_detail view and template
- define URL pattern for story detail
- test redirect behaviour

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_b_68551679f96c832889d44b9695685611