### PR TITLE
Add public story list page

### DIFF
--- a/taletinker/stories/templates/stories/story_list.html
+++ b/taletinker/stories/templates/stories/story_list.html
@@ -1,0 +1,25 @@
+{% extends "base.html" %}
+{% block title %}Story Library{% endblock %}
+{% block content %}
+<h2>Stories</h2>
+{% if stories %}
+<ul>
+  {% for story in stories %}
+  <li>
+    <a href="{% url 'story_detail' story.id %}">{{ story.texts.first.title }}</a>
+    {% if story.is_anonymous %}
+      by Anonymous
+    {% else %}
+      by {{ story.author.username }}
+    {% endif %}
+  </li>
+  {% endfor %}
+</ul>
+{% else %}
+<p>No stories yet.</p>
+{% endif %}
+{% if user.is_authenticated %}
+<p><a href="{% url 'create_story' %}">Create a new story</a></p>
+{% endif %}
+{% endblock %}
+

--- a/taletinker/stories/tests.py
+++ b/taletinker/stories/tests.py
@@ -93,3 +93,29 @@ class NinjaCreateApiTests(TestCase):
         self.assertEqual(response.json()["title"], "Hi")
         self.assertEqual(response.json()["text"], "Hello")
 
+
+class StoryListAndDetailTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="alice", password="pass")
+        self.client = Client()
+
+    def _create_story(self, title="Title", published=True):
+        story = Story.objects.create(author=self.user, is_published=published)
+        story.texts.create(language="en", title=title, text="Once")
+        return story
+
+    def test_homepage_lists_published_stories(self):
+        self._create_story(title="Visible", published=True)
+        self._create_story(title="Hidden", published=False)
+
+        response = self.client.get(reverse("story_list"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Visible")
+        self.assertNotContains(response, "Hidden")
+
+    def test_story_detail_accessible_anonymously(self):
+        story = self._create_story()
+        response = self.client.get(reverse("story_detail", args=[story.id]))
+        self.assertEqual(response.status_code, 200)
+
+

--- a/taletinker/stories/views.py
+++ b/taletinker/stories/views.py
@@ -1,8 +1,18 @@
 from django.contrib.auth.decorators import login_required
-from django.shortcuts import redirect, render, get_object_or_404
+from django.shortcuts import get_object_or_404, redirect, render
 
 from .forms import StoryCreationForm
 from .models import Story, StoryText
+
+
+def story_list(request):
+    """Public homepage listing published stories."""
+    stories = (
+        Story.objects.filter(is_published=True)
+        .prefetch_related("texts", "author")
+        .order_by("-created_at")
+    )
+    return render(request, "stories/story_list.html", {"stories": stories})
 
 
 @login_required

--- a/taletinker/templates/base.html
+++ b/taletinker/templates/base.html
@@ -20,11 +20,13 @@
 <body>
     <h1><a href="/">TaleTinker</a></h1>
     <p>
+        <a href="{% url 'story_list' %}">Home</a>
         {% if user.is_authenticated %}
-            Logged in as {{ user.username }} |
+            | <a href="{% url 'create_story' %}">New Story</a>
+            | Logged in as {{ user.username }} |
             <a href="{% url 'logout' %}">Logout</a>
         {% else %}
-            <a href="{% url 'login' %}">Login</a>
+            | <a href="{% url 'login' %}">Login</a>
         {% endif %}
     </p>
     {% block content %}{% endblock %}

--- a/taletinker/urls.py
+++ b/taletinker/urls.py
@@ -16,10 +16,9 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.contrib.auth import views as auth_views
-from django.http import HttpResponseRedirect
 from django.urls import path
 
-from taletinker.stories.views import create_story, story_detail
+from taletinker.stories.views import create_story, story_detail, story_list
 from taletinker.accounts.views import LogoutView
 from taletinker.api import api as ninja_api
 
@@ -30,5 +29,5 @@ urlpatterns = [
     path('create/', create_story, name='create_story'),
     path('story/<int:story_id>/', story_detail, name='story_detail'),
     path('api/', ninja_api.urls),
-    path('', lambda request: HttpResponseRedirect('/create/')),
+    path('', story_list, name='story_list'),
 ]


### PR DESCRIPTION
## Summary
- create `story_list` view to serve as homepage
- list published stories with simple navigation
- update base template navigation
- expose new view at `/`
- test anonymous access to homepage and story detail

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_b_68551d4fe2548328aa4cd64ffbf4bea6