### PR TITLE
Add story filters

### DIFF
--- a/taletinker/stories/tests.py
+++ b/taletinker/stories/tests.py
@@ -124,6 +124,27 @@ class StoryListAndDetailTests(TestCase):
         response = self.client.get(reverse("story_detail", args=[story.id]))
         self.assertContains(response, 'class="like-btn"')
 
+    def test_filter_my_stories(self):
+        my_story = self._create_story(title="Mine", published=True)
+        other = User.objects.create_user(username="bob", password="pass")
+        other_story = Story.objects.create(author=other, is_published=True)
+        other_story.texts.create(language="en", title="Other", text="X")
+
+        self.client.force_login(self.user)
+        resp = self.client.get(reverse("story_list") + "?filter=mine")
+        self.assertContains(resp, "Mine")
+        self.assertNotContains(resp, "Other")
+
+    def test_filter_my_favorites(self):
+        fav = self._create_story(title="Fav", published=True)
+        not_fav = self._create_story(title="Not", published=True)
+        fav.liked_by.add(self.user)
+
+        self.client.force_login(self.user)
+        resp = self.client.get(reverse("story_list") + "?filter=favorites")
+        self.assertContains(resp, "Fav")
+        self.assertNotContains(resp, "Not")
+
 
 class LikeApiTests(TestCase):
     def setUp(self):

--- a/taletinker/stories/views.py
+++ b/taletinker/stories/views.py
@@ -6,12 +6,20 @@ from .models import Story, StoryText
 
 
 def story_list(request):
-    """Public homepage listing published stories."""
+    """Public homepage listing published stories with optional filters."""
+
     stories = (
         Story.objects.filter(is_published=True)
         .prefetch_related("texts", "author")
         .order_by("-created_at")
     )
+
+    filter_param = request.GET.get("filter")
+    if filter_param == "mine" and request.user.is_authenticated:
+        stories = stories.filter(author=request.user)
+    elif filter_param == "favorites" and request.user.is_authenticated:
+        stories = stories.filter(liked_by=request.user)
+
     return render(request, "stories/story_list.html", {"stories": stories})
 
 

--- a/taletinker/templates/base.html
+++ b/taletinker/templates/base.html
@@ -33,6 +33,22 @@
               <li class="nav-item">
                 <a class="nav-link" href="{% url 'create_story' %}">New Story</a>
               </li>
+              <li class="nav-item dropdown">
+                <a
+                  class="nav-link dropdown-toggle"
+                  href="#"
+                  id="storyDropdown"
+                  role="button"
+                  data-bs-toggle="dropdown"
+                  aria-expanded="false"
+                >
+                  Stories
+                </a>
+                <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="storyDropdown">
+                  <li><a class="dropdown-item" href="{% url 'story_list' %}?filter=mine">My Stories</a></li>
+                  <li><a class="dropdown-item" href="{% url 'story_list' %}?filter=favorites">My Favorites</a></li>
+                </ul>
+              </li>
               <li class="nav-item">
                 <span class="navbar-text">{{ user.username }}</span>
               </li>


### PR DESCRIPTION
## Summary
- allow filtering story list for current user or favorites
- add dropdown in navbar for My Stories and My Favorites
- test new filters

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_b_68552e85fdd0832883e3a03838cdfa62