### PR TITLE
Trigger image creation after story creation

### DIFF
--- a/taletinker/stories/templates/stories/story_detail.html
+++ b/taletinker/stories/templates/stories/story_detail.html
@@ -3,7 +3,20 @@
 {% block content %}
 <h2>{{ story.texts.first.title }}</h2>
 {% if story.images.first %}
-  <img src="{{ story.images.first.image.url }}" class="img-fluid mb-3" alt="Cover image" />
+  <div id="image-container">
+    <img src="{{ story.images.first.image.url }}" class="img-fluid mb-3" alt="Cover image" />
+  </div>
+{% else %}
+  <p id="image-status">Creating image...</p>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      fetch('/api/create_image', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ story_id: {{ story.id }} })
+      }).then(resp => { if (resp.ok) location.reload(); });
+    });
+  </script>
 {% endif %}
 <p>
   <span

--- a/taletinker/stories/tests.py
+++ b/taletinker/stories/tests.py
@@ -208,3 +208,27 @@ class StoryImageDisplayTests(TestCase):
         resp = self.client.get(reverse("story_detail", args=[story.id]))
         self.assertContains(resp, "<img")
 
+
+class ImageCreationFlowTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="flow", password="pass")
+        self.client = Client()
+
+    def test_detail_shows_creation_message_after_story_post(self):
+        self.client.force_login(self.user)
+        data = {
+            "realism": 50,
+            "didactic": 50,
+            "age": 5,
+            "themes": ["family"],
+            "purposes": ["joyful"],
+            "characters": "Jane",
+            "extra_instructions": "A test story.",
+            "story_length": "short",
+            "language": "en",
+            "story_text": "Once",
+            "story_title": "T",
+        }
+        resp = self.client.post(reverse("create_story"), data, follow=True)
+        self.assertContains(resp, "Creating image...")
+


### PR DESCRIPTION
## Summary
- automatically create a StoryImage after a story is created
- display a temporary 'Creating image...' message until the image is ready
- test that the detail page shows the new message

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_b_68553a13088c8328b483debc454bd24e