### PR TITLE
Add RSS feeds per language

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ TaleTinker lets parents craft personalized tales in seconds—tuning realism, th
 * **Rich Controls** – Sliders for realism vs. fantasy, didactic vs. fun, target age (3 – 10+), themes, emotional purpose, language, length, and custom prompts.
 * **On‑Demand Translations** – Base stories can be automatically translated into multiple languages with matching narration.
 * **Public Library** – Browse, search, like, and bookmark stories; filter by age, theme, language, or popularity.
+* **RSS Feeds** – Subscribe to new stories in any supported language.
 * **Freemium Model** – Monthly quota for free users; premium subscribers unlock higher limits, audio downloads, and narrator voice options.
 * **Moderation & Privacy** – OpenAI moderation checks every story; authors may publish under a nickname or anonymously.
 * **Modern Tech Stack** – Django + Django REST Framework, React (or Django templates), PostgreSQL, Celery, AWS S3, Stripe billing.

--- a/taletinker/settings.py
+++ b/taletinker/settings.py
@@ -44,6 +44,7 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "django.contrib.syndication",
     "widget_tweaks",
     'django_recaptcha',
     'django_ses',

--- a/taletinker/stories/feeds.py
+++ b/taletinker/stories/feeds.py
@@ -1,0 +1,45 @@
+from django.contrib.syndication.views import Feed
+from django.urls import reverse
+from django.conf import settings
+from django.http import Http404
+
+from .models import StoryText
+
+
+class LatestStoriesByLanguage(Feed):
+    """RSS feed of latest published stories filtered by language."""
+
+    def get_object(self, request, language: str) -> str:
+        supported = [code for code, _ in settings.LANGUAGES]
+        if language not in supported:
+            raise Http404("Language not supported")
+        return language
+
+    def title(self, language: str) -> str:  # pragma: no cover - simple
+        label = dict(settings.LANGUAGES).get(language, language)
+        return f"Latest TaleTinker stories in {label}"
+
+    def link(self, language: str) -> str:  # pragma: no cover - simple
+        return reverse("story_list") + f"?language={language}"
+
+    def description(self, language: str) -> str:  # pragma: no cover - simple
+        label = dict(settings.LANGUAGES).get(language, language)
+        return f"Recent published stories in {label}"
+
+    def items(self, language: str):
+        return (
+            StoryText.objects.filter(
+                language=language, story__is_published=True
+            )
+            .select_related("story")
+            .order_by("-story__created_at")[:20]
+        )
+
+    def item_title(self, item: StoryText) -> str:
+        return item.title
+
+    def item_description(self, item: StoryText) -> str:
+        return item.text
+
+    def item_link(self, item: StoryText) -> str:  # pragma: no cover - simple
+        return reverse("story_detail", args=[item.story_id]) + f"?lang={item.language}"

--- a/taletinker/urls.py
+++ b/taletinker/urls.py
@@ -31,6 +31,7 @@ from taletinker.stories.views import (
     reorder_playlist,
     play_playlist,
 )
+from taletinker.stories.feeds import LatestStoriesByLanguage
 from taletinker.accounts.views import LogoutView, SignupView, EmailLoginView
 from taletinker.api import api as ninja_api
 
@@ -47,6 +48,7 @@ urlpatterns = [
     path('playlist/remove/<int:story_id>/', remove_from_playlist, name='remove_from_playlist'),
     path('playlist/reorder/', reorder_playlist, name='reorder_playlist'),
     path('playlist/play/', play_playlist, name='play_playlist'),
+    path('rss/<str:language>/', LatestStoriesByLanguage(), name='story_feed'),
     path('api/', ninja_api.urls),
     path('', story_list, name='story_list'),
 ]


### PR DESCRIPTION
## Summary
- provide `LatestStoriesByLanguage` RSS feed
- expose new `rss/<language>/` route
- enable Django syndication
- document new feeds feature
- test RSS feed output

## Testing
- `python manage.py test -v 0`

------
https://chatgpt.com/codex/tasks/task_b_6859424a17e88328a210fd025829b9bb