### PR TITLE
Publish stories on image creation

### DIFF
--- a/taletinker/stories/models.py
+++ b/taletinker/stories/models.py
@@ -60,6 +60,14 @@ class StoryImage(models.Model):
     def __str__(self):
         return f"Cover photo for story {self.story.pk}"
 
+    def save(self, *args, **kwargs):
+        """Save image and automatically publish the related story."""
+        result = super().save(*args, **kwargs)
+        if not self.story.is_published:
+            self.story.is_published = True
+            self.story.save(update_fields=["is_published"])
+        return result
+
 
 class StoryAudio(models.Model):
     story = models.ForeignKey(Story, on_delete=models.CASCADE, related_name="audios")

--- a/taletinker/stories/tests.py
+++ b/taletinker/stories/tests.py
@@ -271,6 +271,8 @@ class CreateImageApiTests(TestCase):
         )
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(self.story.images.count(), 1)
+        self.story.refresh_from_db()
+        self.assertTrue(self.story.is_published)
 
 
 class CreateAudioApiTests(TestCase):


### PR DESCRIPTION
## Summary
- publish stories automatically when a `StoryImage` is saved
- verify publishing in the image creation API test

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_b_685d96cd421c83288a56b56ccb547884