### PR TITLE
Fix dynamic media URLs for S3

### DIFF
--- a/taletinker/settings.py
+++ b/taletinker/settings.py
@@ -79,6 +79,7 @@ TEMPLATES = [
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
                 "django.template.context_processors.i18n",
+                "django.template.context_processors.media",
             ],
         },
     },

--- a/taletinker/stories/templates/stories/story_detail.html
+++ b/taletinker/stories/templates/stories/story_detail.html
@@ -68,7 +68,7 @@
                 container.className = 'w-50 m-2';
                 container.style.float = 'right';
                 const img = document.createElement('img');
-                img.src = '/media/images/cover_{{ story.id }}.png?' + Date.now();
+                img.src = '{{ MEDIA_URL }}images/cover_{{ story.id }}.png?' + Date.now();
                 img.className = 'img-fluid mb-3 rounded';
                 img.alt = 'Cover image';
                 container.appendChild(img);
@@ -119,7 +119,7 @@
                 const audio = document.createElement('audio');
                 audio.controls = true;
                 const source = document.createElement('source');
-                source.src = '/media/' + data.file + '?' + Date.now();
+                source.src = '{{ MEDIA_URL }}' + data.file + '?' + Date.now();
                 source.type = 'audio/mpeg';
                 audio.appendChild(source);
                 container.appendChild(audio);

--- a/taletinker/stories/templates/stories/story_list.html
+++ b/taletinker/stories/templates/stories/story_list.html
@@ -43,7 +43,7 @@
             audio.controls = true;
             audio.className = 'w-100';
             const source = document.createElement('source');
-            source.src = '/media/' + data.file + '?' + Date.now();
+            source.src = '{{ MEDIA_URL }}' + data.file + '?' + Date.now();
             source.type = 'audio/mpeg';
             audio.appendChild(source);
             container.appendChild(audio);


### PR DESCRIPTION
## Summary
- ensure `MEDIA_URL` is available to templates
- build generated image and audio URLs using `MEDIA_URL`

## Testing
- `RECAPTCHA_PUBLIC_KEY=x RECAPTCHA_PRIVATE_KEY=x python manage.py test -v 0`

------
https://chatgpt.com/codex/tasks/task_b_685d9d2e9bc0832890ee01caffe6102b