### PR TITLE
Update create story form

### DIFF
--- a/taletinker/api.py
+++ b/taletinker/api.py
@@ -26,14 +26,14 @@ class StoryParams(BaseModel):
     themes: List[str] = Field(default_factory=list)
     purposes: List[str] = Field(default_factory=list)
     characters: str = ""
-    story_length: str = "short"
+    story_length: int = Field(1, ge=1, le=5)
     extra_instructions: str = ""
     language: str = "en"
 
 
 def build_prompt(params: StoryParams) -> str:
     parts = [
-        f"Write a {params.story_length} children's story suitable for a {params.age}-year-old child.",
+        f"Write a {params.story_length}-minute children's story suitable for a {params.age}-year-old child.",
         f"Balance realism vs fantasy at {params.realism}/100.",
         f"Balance didactic vs fun at {params.didactic}/100.",
     ]

--- a/taletinker/stories/forms.py
+++ b/taletinker/stories/forms.py
@@ -9,6 +9,8 @@ THEME_CHOICES = [
     ("animals", "Animals"),
     ("courage", "Courage"),
     ("technology", "Technology"),
+    ("dinosaurs", "Dinosaurs"),
+    ("machines", "Machines"),
 ]
 
 PURPOSE_CHOICES = [
@@ -18,9 +20,11 @@ PURPOSE_CHOICES = [
 ]
 
 LENGTH_CHOICES = [
-    ("short", "Short"),
-    ("medium", "Medium"),
-    ("long", "Long"),
+    ("1", "1 minute"),
+    ("2", "2 minutes"),
+    ("3", "3 minutes"),
+    ("4", "4 minutes"),
+    ("5", "5 minutes"),
 ]
 
 
@@ -92,9 +96,6 @@ class StoryCreationForm(forms.Form):
         choices=LENGTH_CHOICES,
         label="Story Length",
         widget=forms.Select(attrs={"class": "form-select"}),
-    )
-    language = forms.ChoiceField(
-        choices=settings.LANGUAGES, widget=forms.Select(attrs={"class": "form-select"})
     )
 
 

--- a/taletinker/stories/templates/stories/create_story.html
+++ b/taletinker/stories/templates/stories/create_story.html
@@ -54,7 +54,7 @@ form.addEventListener('submit', async e=>{
         purposes: [...form.querySelectorAll('input[name="purposes"]:checked')].map(el=>el.value),
         extra_instructions: form.extra_instructions.value,
         story_length: form.story_length.value,
-        language: form.language.value,
+        language: "{{ LANGUAGE_CODE }}",
     };
 
     try{
@@ -122,7 +122,6 @@ form.addEventListener('submit', async e=>{
 
   <div class="mb-3">{{ form.extra_instructions.label_tag }} {{ form.extra_instructions }}</div>
   <div class="mb-3">{{ form.story_length.label_tag }} {{ form.story_length }}</div>
-  <div class="mb-3">{{ form.language.label_tag }} {{ form.language }}</div>
 
   <button type="submit" class="btn btn-primary">Generate Story</button>
   <div id="spinner">Generating…</div>

--- a/taletinker/stories/tests.py
+++ b/taletinker/stories/tests.py
@@ -31,8 +31,7 @@ class CreateStoryViewTests(TestCase):
             "purposes": ["joyful"],
             "characters": "Jane",
             "extra_instructions": "A test story.",
-            "story_length": "short",
-            "language": "en",
+            "story_length": "1",
             "story_text": "Once upon a time",
             "story_title": "My Story",
         }
@@ -55,8 +54,7 @@ class CreateStoryViewTests(TestCase):
             "purposes": ["joyful"],
             "characters": "Jane",
             "extra_instructions": "A test story.",
-            "story_length": "short",
-            "language": "en",
+            "story_length": "1",
             "story_text": "Once upon a time",
             "story_title": "My Story",
         }
@@ -86,7 +84,7 @@ class NinjaCreateApiTests(TestCase):
                 "realism": 3,
                 "didactic": 3,
                 "age": 5,
-                "story_length": "short",
+                "story_length": 1,
             },
             content_type="application/json",
         )
@@ -464,8 +462,7 @@ class ImageCreationFlowTests(TestCase):
             "purposes": ["joyful"],
             "characters": "Jane",
             "extra_instructions": "A test story.",
-            "story_length": "short",
-            "language": "en",
+            "story_length": "1",
             "story_text": "Once",
             "story_title": "T",
         }

--- a/taletinker/stories/views.py
+++ b/taletinker/stories/views.py
@@ -2,6 +2,7 @@ from django.contrib.auth.decorators import login_required
 from django.shortcuts import get_object_or_404, redirect, render
 from django.conf import settings
 from django.http import JsonResponse
+from django.utils.translation import get_language
 from django.db.models import Count
 from django.core.paginator import Paginator
 
@@ -133,14 +134,14 @@ def create_story(request):
                     "story_length": form.cleaned_data["story_length"],
                 },
                 prompt=form.cleaned_data["extra_instructions"],
-                original_language=form.cleaned_data["language"],
+                original_language=get_language(),
             )
             text = request.POST.get("story_text")
             title = request.POST.get("story_title")
             if text:
                 StoryText.objects.create(
                     story=story,
-                    language=form.cleaned_data["language"],
+                    language=get_language(),
                     title=title or (text.splitlines()[0][:255] if text.strip() else "Story"),
                     text=text,
                 )


### PR DESCRIPTION
## Summary
- let create page use user's current language
- add dinosaur and machine themes
- change story length dropdown to 1–5 minutes
- adjust API and tests for new minutes values

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_b_685e15ea92508328b4a6eb650f50ce6d