### PR TITLE
Use slider for story length

### DIFF
--- a/taletinker/stories/forms.py
+++ b/taletinker/stories/forms.py
@@ -19,14 +19,6 @@ PURPOSE_CHOICES = [
     ("support", "Supportive"),
 ]
 
-LENGTH_CHOICES = [
-    ("1", "1 minute"),
-    ("2", "2 minutes"),
-    ("3", "3 minutes"),
-    ("4", "4 minutes"),
-    ("5", "5 minutes"),
-]
-
 
 class StoryCreationForm(forms.Form):
 
@@ -92,10 +84,19 @@ class StoryCreationForm(forms.Form):
         label="Extra Instructions",
     )
 
-    story_length = forms.ChoiceField(
-        choices=LENGTH_CHOICES,
+    story_length = forms.IntegerField(
+        min_value=1,
+        max_value=5,
+        initial=1,
+        widget=forms.NumberInput(
+            attrs={
+                "type": "range",
+                "step": 1,
+                "class": "form-range",
+                "list": "length-ticks",
+            }
+        ),
         label="Story Length",
-        widget=forms.Select(attrs={"class": "form-select"}),
     )
 
 

--- a/taletinker/stories/templates/stories/create_story.html
+++ b/taletinker/stories/templates/stories/create_story.html
@@ -121,7 +121,17 @@ form.addEventListener('submit', async e=>{
   </div>
 
   <div class="mb-3">{{ form.extra_instructions.label_tag }} {{ form.extra_instructions }}</div>
-  <div class="mb-3">{{ form.story_length.label_tag }} {{ form.story_length }}</div>
+  <div class="mb-3">
+    {{ form.story_length.label_tag }} (1–5 min)
+    {{ form.story_length }}
+    <datalist id="length-ticks">
+      {% for i in '1234' %}<option value="{{ i }}"></option>{% endfor %}
+      <option value="5"></option>
+    </datalist>
+    <div class="d-flex justify-content-between small text-muted px-1">
+      <span>1</span><span>2</span><span>3</span><span>4</span><span>5</span>
+    </div>
+  </div>
 
   <button type="submit" class="btn btn-primary">Generate Story</button>
   <div id="spinner">Generating…</div>


### PR DESCRIPTION
## Summary
- convert `story_length` field to a range input
- add slider UI to the create story page

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_b_685e18b9dba483288b84c012fccdb4f5