### PR TITLE
Improve Bootstrap layout for login/signup

### DIFF
--- a/taletinker/templates/registration/login_email.html
+++ b/taletinker/templates/registration/login_email.html
@@ -1,27 +1,32 @@
 {% extends "base.html" %}
+{% load widget_tweaks %}
 {% block title %}Email Login{% endblock %}
 {% block content %}
-<h2>Email Login</h2>
-<form method="post" class="mb-3">
-  {% csrf_token %}
-  {{ form.non_field_errors }}
-  <div class="mb-3">
-    {{ form.email.label_tag }}
-    {{ form.email }}
-    {% if form.email.errors %}
-      <div class="text-danger small">{{ form.email.errors|join:" " }}</div>
-    {% endif %}
+<h2 class="text-center mb-4">Email Login</h2>
+<div class="row justify-content-center">
+  <div class="col-md-6 col-lg-4">
+    <form method="post" class="mb-3">
+      {% csrf_token %}
+      {{ form.non_field_errors }}
+      <div class="mb-3">
+        {{ form.email.label_tag }}
+        {{ form.email|add_class:"form-control" }}
+        {% if form.email.errors %}
+          <div class="text-danger small">{{ form.email.errors|join:" " }}</div>
+        {% endif %}
+      </div>
+      <div class="mb-3">
+        {{ form.captcha }}
+        {% if form.captcha.errors %}
+          <div class="text-danger small">{{ form.captcha.errors|join:" " }}</div>
+        {% endif %}
+      </div>
+      {% if next %}
+        <input type="hidden" name="next" value="{{ next }}" />
+      {% endif %}
+      <button type="submit" class="btn btn-primary w-100">Send Login Link</button>
+    </form>
+    <p class="mt-3 text-center">Not registered? <a href="{% url 'signup' %}">Sign Up</a></p>
   </div>
-  <div class="mb-3">
-    {{ form.captcha }}
-    {% if form.captcha.errors %}
-      <div class="text-danger small">{{ form.captcha.errors|join:" " }}</div>
-    {% endif %}
-  </div>
-  {% if next %}
-    <input type="hidden" name="next" value="{{ next }}" />
-  {% endif %}
-  <button type="submit" class="btn btn-primary">Send Login Link</button>
-</form>
-<p class="mt-3">Not registered? <a href="{% url 'signup' %}">Sign Up</a></p>
+</div>
 {% endblock %}

--- a/taletinker/templates/registration/signup.html
+++ b/taletinker/templates/registration/signup.html
@@ -1,25 +1,30 @@
 {% extends "base.html" %}
+{% load widget_tweaks %}
 {% block title %}Sign Up{% endblock %}
 {% block content %}
-<h2>Sign Up</h2>
-<form method="post" class="mb-3">
-  {% csrf_token %}
-  {{ form.non_field_errors }}
-  <div class="mb-3">
-    {{ form.username.label_tag }}
-    {{ form.username }}
+<h2 class="text-center mb-4">Sign Up</h2>
+<div class="row justify-content-center">
+  <div class="col-md-6 col-lg-4">
+    <form method="post" class="mb-3">
+      {% csrf_token %}
+      {{ form.non_field_errors }}
+      <div class="mb-3">
+        {{ form.username.label_tag }}
+        {{ form.username|add_class:"form-control" }}
+      </div>
+      <div class="mb-3">
+        {{ form.email.label_tag }}
+        {{ form.email|add_class:"form-control" }}
+      </div>
+      <div class="mb-3">
+        {{ form.captcha }}
+      </div>
+      {% if next %}
+        <input type="hidden" name="next" value="{{ next }}" />
+      {% endif %}
+      <button type="submit" class="btn btn-primary w-100">Sign Up</button>
+    </form>
+    <p class="mt-3 text-center">Already have an account? <a href="{% url 'login' %}">Login</a></p>
   </div>
-  <div class="mb-3">
-    {{ form.email.label_tag }}
-    {{ form.email }}
-  </div>
-  <div class="mb-3">
-    {{ form.captcha }}
-  </div>
-  {% if next %}
-    <input type="hidden" name="next" value="{{ next }}" />
-  {% endif %}
-  <button type="submit" class="btn btn-primary">Sign Up</button>
-</form>
-<p class="mt-3">Already have an account? <a href="{% url 'login' %}">Login</a></p>
+</div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- center the signup form and add Bootstrap styling
- center the login form and add Bootstrap styling

## Testing
- `python manage.py test` *(fails: ImproperlyConfigured - RECAPTCHA_PRIVATE_KEY)*

------
https://chatgpt.com/codex/tasks/task_b_685e2158bb308328b4fe7d666c09b430