### PR TITLE
Normalize stored language codes

### DIFF
--- a/taletinker/stories/models.py
+++ b/taletinker/stories/models.py
@@ -3,6 +3,13 @@ from django.db import models
 import uuid
 
 
+def _normalize_lang(code: str | None) -> str | None:
+    """Return the top-level language for codes like ``en-us``."""
+    if not code:
+        return code
+    return code.split("-")[0]
+
+
 class Story(models.Model):
     author = models.ForeignKey(
         settings.AUTH_USER_MODEL,
@@ -34,6 +41,11 @@ class Story(models.Model):
     def __str__(self):
         return f"Story by {self.author} @{self.created_at} in {self.original_language}"
 
+    def save(self, *args, **kwargs):
+        if self.original_language:
+            self.original_language = _normalize_lang(self.original_language)
+        return super().save(*args, **kwargs)
+
     @property
     def languages(self) -> list[str]:
         """Return list of language codes available for this story."""
@@ -52,6 +64,11 @@ class StoryText(models.Model):
 
     def __str__(self):
         return self.title
+
+    def save(self, *args, **kwargs):
+        if self.language:
+            self.language = _normalize_lang(self.language)
+        return super().save(*args, **kwargs)
 
 
 class StoryImage(models.Model):
@@ -84,6 +101,11 @@ class StoryAudio(models.Model):
 
     def __str__(self):
         return f"Naration of story {self.story.pk} in {self.language}"
+
+    def save(self, *args, **kwargs):
+        if self.language:
+            self.language = _normalize_lang(self.language)
+        return super().save(*args, **kwargs)
 
 
 class Playlist(models.Model):

--- a/taletinker/stories/tests.py
+++ b/taletinker/stories/tests.py
@@ -62,6 +62,26 @@ class CreateStoryViewTests(TestCase):
         story = Story.objects.first()
         self.assertRedirects(response, reverse("story_detail", args=[story.uuid]))
 
+    def test_language_normalized(self):
+        self.client.force_login(self.user)
+        from django.utils.translation import activate, deactivate
+
+        activate("en-us")
+        data = {
+            "realism": 3,
+            "didactic": 3,
+            "age": 5,
+            "themes": ["family"],
+            "story_length": "1",
+        }
+        try:
+            self.client.post(reverse("create_story"), data)
+        finally:
+            deactivate()
+        story = Story.objects.first()
+        self.assertEqual(story.original_language, "en")
+        self.assertEqual(story.texts.first().language, "en")
+
 
 class NinjaCreateApiTests(TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary
- normalize language codes for `Story`, `StoryText`, and `StoryAudio`
- ensure normalization tested in `CreateStoryViewTests`

## Testing
- `pre-commit run --all-files` *(fails: command not found)*
- `pytest -q` *(no tests ran)*

------
https://chatgpt.com/codex/tasks/task_b_685e51b603b4832889b1a8504c029fc3