### PR TITLE
Mark strings for translation

### DIFF
--- a/taletinker/stories/templates/stories/create_story.html
+++ b/taletinker/stories/templates/stories/create_story.html
@@ -1,8 +1,8 @@
 {# templates/create_story.html #}
 {% extends "base.html" %}
-{% load static %}
+{% load static i18n %}
 
-{% block title %}Create Story{% endblock %}
+{% block title %}{% trans "Create Story" %}{% endblock %}
 
 {% block extra_head %}
 <style>
@@ -92,21 +92,21 @@ form.addEventListener('submit', async e=>{
   <input type="hidden" name="story_text"  id="story_text">
   <input type="hidden" name="story_title" id="story_title">
 
-  <h5 class="mt-3">Tone &amp; Audience</h5>
+  <h5 class="mt-3">{% trans "Tone &amp; Audience" %}</h5>
 
   <div class="mb-3">
     {{ form.realism.label_tag }} {{ form.realism }}
     <div class="d-flex justify-content-between small text-muted px-1">
-      <span>realistic</span><span>moderately realistic</span><span>balanced</span>
-      <span>moderately fantastic</span><span>fantastic</span>
+      <span>{% trans "realistic" %}</span><span>{% trans "moderately realistic" %}</span><span>{% trans "balanced" %}</span>
+      <span>{% trans "moderately fantastic" %}</span><span>{% trans "fantastic" %}</span>
     </div>
   </div>
 
   <div class="mb-3">
     {{ form.didactic.label_tag }} {{ form.didactic }}
     <div class="d-flex justify-content-between small text-muted px-1">
-      <span>didactic</span><span>mostly didactic</span><span>balanced</span>
-      <span>mostly fun</span><span>just for fun</span>
+      <span>{% trans "didactic" %}</span><span>{% trans "mostly didactic" %}</span><span>{% trans "balanced" %}</span>
+      <span>{% trans "mostly fun" %}</span><span>{% trans "just for fun" %}</span>
     </div>
   </div>
 
@@ -123,7 +123,7 @@ form.addEventListener('submit', async e=>{
   </div>
 
   <div class="mb-3">
-    <label class="form-label">Themes</label>
+    <label class="form-label">{% trans "Themes" %}</label>
     <div class="chips">{% for cb in form.themes %}<div class="chip">{{ cb }}</div>{% endfor %}</div>
   </div>
 
@@ -132,7 +132,7 @@ form.addEventListener('submit', async e=>{
     {{ form.extra_instructions.label_tag }}
     <div class="input-group">
       {{ form.extra_instructions }}
-      <button type="button" class="btn btn-outline-secondary" id="random-idea-btn">Surprise Me</button>
+      <button type="button" class="btn btn-outline-secondary" id="random-idea-btn">{% trans "Surprise Me" %}</button>
     </div>
   </div>
   <div class="mb-3">
@@ -147,7 +147,7 @@ form.addEventListener('submit', async e=>{
     </div>
   </div>
 
-  <button type="submit" class="btn btn-primary">Generate Story</button>
-  <div id="spinner">Generating…</div>
+  <button type="submit" class="btn btn-primary">{% trans "Generate Story" %}</button>
+  <div id="spinner">{% trans "Generating…" %}</div>
 </form>
 {% endblock %}

--- a/taletinker/stories/templates/stories/playlist_play.html
+++ b/taletinker/stories/templates/stories/playlist_play.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
-{% block title %}Play Playlist{% endblock %}
+{% load i18n %}
+{% block title %}{% trans "Play Playlist" %}{% endblock %}
 {% block extra_head %}
 <script>
   document.addEventListener('DOMContentLoaded', () => {
@@ -68,7 +69,7 @@
 </script>
 {% endblock %}
 {% block content %}
-<h2 class="mb-3">My Playlist</h2>
+<h2 class="mb-3">{% trans "My Playlist" %}</h2>
 <p id="playlist-summary" class="small text-muted">0 stories – 0:00</p>
 <ul class="list-group mb-3" id="playlist">
   {% for story in stories %}
@@ -82,15 +83,15 @@
             <source src="{{ audio.mp3.url }}" type="audio/mpeg" />
           </audio>
         {% else %}
-          <span class="text-muted small">No audio</span>
+          <span class="text-muted small">{% trans "No audio" %}</span>
         {% endif %}
       </div>
     </li>
     {% endwith %}
   {% empty %}
-    <li class="list-group-item">No stories.</li>
+    <li class="list-group-item">{% trans "No stories." %}</li>
   {% endfor %}
 </ul>
 <audio id="playlist-player" controls class="w-100 mb-3"></audio>
-<a href="{% url 'story_list' %}" class="btn btn-secondary">Back</a>
+<a href="{% url 'story_list' %}" class="btn btn-secondary">{% trans "Back" %}</a>
 {% endblock %}

--- a/taletinker/stories/templates/stories/story_cards.html
+++ b/taletinker/stories/templates/stories/story_cards.html
@@ -1,3 +1,4 @@
+{% load i18n %}
 {% for story in stories %}
 <div class="col">
   <div class="card h-100">
@@ -21,7 +22,7 @@
 
       <figcaption class="blockquote-footer">
           {% if story.is_anonymous %}
-              Anonymous
+              {% trans "Anonymous" %}
           {% else %}
               {{ story.author.username }}
           {% endif %}
@@ -38,7 +39,7 @@
       {% else %}
         <div id="audio-status-{{ story.id }}" data-create-audio data-story-id="{{ story.id }}" data-language="{{ story.display_language }}" class="mt-auto">
           <div class="progress">
-            <div class="progress-bar progress-bar-striped progress-bar-animated" id="audio-progress-{{ story.id }}" data-duration="60000" style="width: 0%">Creating audio...</div>
+            <div class="progress-bar progress-bar-striped progress-bar-animated" id="audio-progress-{{ story.id }}" data-duration="60000" style="width: 0%">{% trans "Creating audio..." %}</div>
           </div>
         </div>
       {% endif %}
@@ -53,7 +54,7 @@
             <form method="post" action="{% url 'add_to_playlist' story.id %}" class="d-inline">
               {% csrf_token %}
               <button id="add-btn-{{ story.id }}" type="submit" class="btn btn-link text-dark p-0 fw-bolder"
-                      data-bs-toggle="tooltip" data-bs-title="Add to Playlist"
+                      data-bs-toggle="tooltip" data-bs-title="{% trans 'Add to Playlist' %}"
                       {% if not story.display_audio %}disabled{% endif %}
               ><i class="bi bi-plus-circle"></i></button>
             </form>
@@ -62,7 +63,7 @@
 
             <a href="{% url 'signup' %}"
                     class="btn btn-link text-dark p-0 fw-bolder text-reset text-decoration-none"
-                  data-bs-toggle="tooltip" data-bs-title="Add to Playlist"
+                  data-bs-toggle="tooltip" data-bs-title="{% trans 'Add to Playlist' %}"
             ><i class="bi bi-plus-circle"></i></a>
 
         {% endif %}

--- a/taletinker/stories/templates/stories/story_detail.html
+++ b/taletinker/stories/templates/stories/story_detail.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
-{% block title %}Story Detail{% endblock %}
+{% load i18n %}
+{% block title %}{% trans "Story Detail" %}{% endblock %}
 
 {% block extra_head %}
 <script type="application/ld+json">
@@ -33,7 +34,7 @@
           {% endif %}
       </span>
       <span class="like-count text-secondary">{{ story.liked_by.count }}</span>
-      <a href="#" class="share-btn fs-4 ms-3" data-url="{{ request.build_absolute_uri }}" data-title="{{ text.title }}" data-bs-toggle="tooltip" data-bs-title="Share Story">
+      <a href="#" class="share-btn fs-4 ms-3" data-url="{{ request.build_absolute_uri }}" data-title="{{ text.title }}" data-bs-toggle="tooltip" data-bs-title="{% trans 'Share Story' %}">
           <i class="bi bi-share"></i>
       </a>
     </p>
@@ -59,7 +60,7 @@
     {% else %}
       <div id="image-status" class="w-50 m-2" style="float: right;">
         <div class="progress">
-          <div id="image-progress" class="progress-bar progress-bar-striped progress-bar-animated" data-duration="20000" style="width: 0%">Creating image...</div>
+          <div id="image-progress" class="progress-bar progress-bar-striped progress-bar-animated" data-duration="20000" style="width: 0%">{% trans 'Creating image...' %}</div>
         </div>
       </div>
       <script>
@@ -109,7 +110,7 @@
     {% else %}
       <div id="audio-status" class="my-3">
         <div class="progress">
-          <div id="audio-progress" class="progress-bar progress-bar-striped progress-bar-animated" data-duration="60000" style="width: 0%">Creating audio...</div>
+          <div id="audio-progress" class="progress-bar progress-bar-striped progress-bar-animated" data-duration="60000" style="width: 0%">{% trans 'Creating audio...' %}</div>
         </div>
       </div>
       <script>
@@ -156,7 +157,7 @@
     {% else %}
       <div id="text-status" class="my-3">
         <div class="progress">
-          <div id="text-progress" class="progress-bar progress-bar-striped progress-bar-animated" data-duration="10000" style="width: 0%">Creating text...</div>
+          <div id="text-progress" class="progress-bar progress-bar-striped progress-bar-animated" data-duration="10000" style="width: 0%">{% trans 'Creating text...' %}</div>
         </div>
       </div>
       <script>

--- a/taletinker/stories/templates/stories/story_list.html
+++ b/taletinker/stories/templates/stories/story_list.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
-{% block title %}Story Library{% endblock %}
+{% load i18n %}
+{% block title %}{% trans "Story Library" %}{% endblock %}
 {% block extra_head %}
 <style>
   #playlist-panel {
@@ -201,7 +202,7 @@
 {% endblock %}
 {% block content %}
 <div class="d-flex justify-content-between align-items-center mb-3">
-  <h1 class="mb-0 fs-2">Stories</h1>
+  <h1 class="mb-0 fs-2">{% trans "Stories" %}</h1>
 </div>
 
 <!-- one flex row, everything bottoms-out on the same line -->
@@ -228,7 +229,7 @@
         {{ form.search }}
       </div>
       <div class="col-12 col-lg-auto">
-        <button type="submit" class="btn btn-secondary w-100 w-lg-auto">Apply</button>
+        <button type="submit" class="btn btn-secondary w-100 w-lg-auto">{% trans "Apply" %}</button>
       </div>
     </form>
   </div>
@@ -236,7 +237,7 @@
   <div class="col-12 col-lg-auto align-self-end">
     <form method="post" action="{% url 'add_filtered_to_playlist' %}?{{ request.GET.urlencode }}">
       {% csrf_token %}
-      <button type="submit" class="btn btn-link p-0">Add listed stories to the playlist</button>
+      <button type="submit" class="btn btn-link p-0">{% trans "Add listed stories to the playlist" %}</button>
     </form>
   </div>
 </div>
@@ -252,10 +253,10 @@
       {% include 'stories/story_cards.html' with stories=stories %}
     </div>
     {% else %}
-    <p>No stories yet.</p>
+    <p>{% trans "No stories yet." %}</p>
 
           {% if request.GET.age or request.GET.theme %}
-            <a class="btn btn-lg btn-success my-3" href="{% url 'create_story' %}?{% if request.GET.age %}age={{ request.GET.age }}{% endif %}{% if request.GET.theme %}{% if request.GET.age %}&amp;{% endif %}themes={{ request.GET.theme }}{% endif %}">Create this story</a>
+            <a class="btn btn-lg btn-success my-3" href="{% url 'create_story' %}?{% if request.GET.age %}age={{ request.GET.age }}{% endif %}{% if request.GET.theme %}{% if request.GET.age %}&amp;{% endif %}themes={{ request.GET.theme }}{% endif %}">{% trans "Create this story" %}</a>
           {% endif %}
 
     {% endif %}
@@ -266,7 +267,7 @@
     <div id="playlist-panel" class="bg-light border p-3 rounded my-0">
 
         <div class="d-flex justify-content-between align-items-center mb-3">
-          <h5 class="mb-0">My Playlist</h5>
+          <h5 class="mb-0">{% trans "My Playlist" %}</h5>
           <p id="playlist-summary" class="small text-muted mb-0">0 stories – 0:00</p>
         </div>
 
@@ -288,7 +289,7 @@
                   <source src="{{ audio.mp3.url }}" type="audio/mpeg" />
                 </audio>
               {% else %}
-                <span class="text-muted small me-2">No audio</span>
+                <span class="text-muted small me-2">{% trans "No audio" %}</span>
               {% endif %}
               <form method="post" action="{% url 'remove_from_playlist' item.id %}" class="ms-2">
                 {% csrf_token %}
@@ -298,13 +299,13 @@
           </li>
           {% endwith %}
         {% empty %}
-          <li class="list-group-item">No stories yet.</li>
+          <li class="list-group-item">{% trans "No stories yet." %}</li>
         {% endfor %}
       </ul>
       <audio id="playlist-player" controls class="w-100"></audio>
     </div>
 
-      <a class="btn btn-lg btn-outline-success my-3 w-100" href="{% url 'create_story' %}">Create your story</a>
+      <a class="btn btn-lg btn-outline-success my-3 w-100" href="{% url 'create_story' %}">{% trans "Create your story" %}</a>
 
   </div>
 </div>

--- a/taletinker/stories/views.py
+++ b/taletinker/stories/views.py
@@ -2,7 +2,7 @@ from django.contrib.auth.decorators import login_required
 from django.shortcuts import get_object_or_404, redirect, render
 from django.conf import settings
 from django.http import JsonResponse
-from django.utils.translation import get_language
+from django.utils.translation import get_language, gettext_lazy as _
 from django.db.models import Count
 from django.core.paginator import Paginator
 from django.core.cache import cache
@@ -155,7 +155,7 @@ def create_story(request):
             StoryText.objects.create(
                 story=story,
                 language=get_language(),
-                title=title or (text.splitlines()[0][:255] if text and text.strip() else "Story"),
+                title=title or (text.splitlines()[0][:255] if text and text.strip() else _("Story")),
                 text=text or "",
             )
             return redirect("story_detail", story_uuid=story.uuid)

--- a/taletinker/templates/base.html
+++ b/taletinker/templates/base.html
@@ -1,9 +1,9 @@
-{% load static %}<!DOCTYPE html>
+{% load static i18n %}<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="TaleTinker lets you craft and share AI-generated children's stories with audio narration and cover art." />
+    <meta name="description" content="{% trans "TaleTinker lets you craft and share AI-generated children's stories with audio narration and cover art." %}" />
     <title>{% block title %}TaleTinker{% endblock %}</title>
 
     <link rel="icon" type="image/x-icon" href="{% static 'fav.png' %}">
@@ -59,10 +59,10 @@ h1, h2, h3, h4, h5, h6 {
             <div class="collapse navbar-collapse" id="navbarSupportedContent">
               <ul class="navbar-nav me-auto mb-2 mb-lg-0">
                 <li class="nav-item">
-                  <a class="nav-link" href="{% url 'story_list' %}">View Stories</a>
+                  <a class="nav-link" href="{% url 'story_list' %}">{% trans "View Stories" %}</a>
                 </li>
                 <li class="nav-item">
-                  <a class="nav-link" href="{% url 'create_story' %}">Create Your Story</a>
+                  <a class="nav-link" href="{% url 'create_story' %}">{% trans "Create Your Story" %}</a>
                 </li>
               </ul>
               <ul class="navbar-nav ms-auto mb-2 mb-lg-0">
@@ -78,11 +78,11 @@ h1, h2, h3, h4, h5, h6 {
                     <i class="bi bi-translate"></i>
                   </a>
                   <ul class="dropdown-menu" aria-labelledby="languageDropdown">
-                    <li><a class="dropdown-item" href="?lang=en">English</a></li>
-                    <li><a class="dropdown-item" href="?lang=es">Spanish</a></li>
-                    <li><a class="dropdown-item" href="?lang=fr">French</a></li>
-                    <li><a class="dropdown-item" href="?lang=de">German</a></li>
-                    <li><a class="dropdown-item" href="?lang=tr">Turkish</a></li>
+                    <li><a class="dropdown-item" href="?lang=en">{% trans "English" %}</a></li>
+                    <li><a class="dropdown-item" href="?lang=es">{% trans "Spanish" %}</a></li>
+                    <li><a class="dropdown-item" href="?lang=fr">{% trans "French" %}</a></li>
+                    <li><a class="dropdown-item" href="?lang=de">{% trans "German" %}</a></li>
+                    <li><a class="dropdown-item" href="?lang=tr">{% trans "Turkish" %}</a></li>
                   </ul>
                 </li>
                 {% if user.is_authenticated %}
@@ -98,18 +98,18 @@ h1, h2, h3, h4, h5, h6 {
                       {{ user.username }}
                     </a>
                     <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="storyDropdown">
-                      <li><a class="dropdown-item" href="{% url 'story_list' %}?filter=mine">My Stories</a></li>
-                      <li><a class="dropdown-item" href="{% url 'story_list' %}?filter=favorites">My Favorites</a></li>
+                      <li><a class="dropdown-item" href="{% url 'story_list' %}?filter=mine">{% trans "My Stories" %}</a></li>
+                      <li><a class="dropdown-item" href="{% url 'story_list' %}?filter=favorites">{% trans "My Favorites" %}</a></li>
                       <li class="dropdown-divider"></li>
-                      <li><a class="dropdown-item" href="{% url 'logout' %}">Logout</a></li>
+                      <li><a class="dropdown-item" href="{% url 'logout' %}">{% trans "Logout" %}</a></li>
                     </ul>
                   </li>
                 {% else %}
                   <li class="nav-item">
-                    <a class="nav-link" href="{% url 'login' %}">Login</a>
+                    <a class="nav-link" href="{% url 'login' %}">{% trans "Login" %}</a>
                   </li>
                   <li class="nav-item">
-                    <a class="nav-link" href="{% url 'signup' %}">Sign Up</a>
+                    <a class="nav-link" href="{% url 'signup' %}">{% trans "Sign Up" %}</a>
                   </li>
                 {% endif %}
               </ul>

--- a/taletinker/templates/registration/login_email.html
+++ b/taletinker/templates/registration/login_email.html
@@ -1,8 +1,8 @@
 {% extends "base.html" %}
-{% load widget_tweaks %}
-{% block title %}Email Login{% endblock %}
+{% load widget_tweaks i18n %}
+{% block title %}{% trans "Email Login" %}{% endblock %}
 {% block content %}
-<h2 class="text-center mb-4">Email Login</h2>
+<h2 class="text-center mb-4">{% trans "Email Login" %}</h2>
 <div class="row justify-content-center">
   <div class="col-md-6 col-lg-4">
     <form method="post" class="mb-3">
@@ -24,9 +24,9 @@
       {% if next %}
         <input type="hidden" name="next" value="{{ next }}" />
       {% endif %}
-      <button type="submit" class="btn btn-primary w-100">Send Login Link</button>
+      <button type="submit" class="btn btn-primary w-100">{% trans "Send Login Link" %}</button>
     </form>
-    <p class="mt-3 text-center">Not registered? <a href="{% url 'signup' %}">Sign Up</a></p>
+    <p class="mt-3 text-center">{% trans "Not registered?" %} <a href="{% url 'signup' %}">{% trans "Sign Up" %}</a></p>
   </div>
 </div>
 {% endblock %}

--- a/taletinker/templates/registration/login_email_sent.html
+++ b/taletinker/templates/registration/login_email_sent.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
-{% block title %}Check Your Email{% endblock %}
+{% load i18n %}
+{% block title %}{% trans "Check Your Email" %}{% endblock %}
 {% block content %}
-<h1>Check Your Email</h1>
-<p>We sent you a login link. Please check your email.</p>
+<h1>{% trans "Check Your Email" %}</h1>
+<p>{% trans "We sent you a login link. Please check your email." %}</p>
 {% endblock %}

--- a/taletinker/templates/registration/signup.html
+++ b/taletinker/templates/registration/signup.html
@@ -1,8 +1,8 @@
 {% extends "base.html" %}
-{% load widget_tweaks %}
-{% block title %}Sign Up{% endblock %}
+{% load widget_tweaks i18n %}
+{% block title %}{% trans "Sign Up" %}{% endblock %}
 {% block content %}
-<h2 class="text-center mb-4">Sign Up</h2>
+<h2 class="text-center mb-4">{% trans "Sign Up" %}</h2>
 <div class="row justify-content-center">
   <div class="col-md-6 col-lg-4">
     <form method="post" class="mb-3">
@@ -22,9 +22,9 @@
       {% if next %}
         <input type="hidden" name="next" value="{{ next }}" />
       {% endif %}
-      <button type="submit" class="btn btn-primary w-100">Sign Up</button>
+      <button type="submit" class="btn btn-primary w-100">{% trans "Sign Up" %}</button>
     </form>
-    <p class="mt-3 text-center">Already have an account? <a href="{% url 'login' %}">Login</a></p>
+    <p class="mt-3 text-center">{% trans "Already have an account?" %} <a href="{% url 'login' %}">{% trans "Login" %}</a></p>
   </div>
 </div>
 {% endblock %}

--- a/taletinker/templates/registration/signup_done.html
+++ b/taletinker/templates/registration/signup_done.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
-{% block title %}Check Your Email{% endblock %}
+{% load i18n %}
+{% block title %}{% trans "Check Your Email" %}{% endblock %}
 {% block content %}
-<h1>Check Your Email</h1>
-<p>Thank you for signing up! We've sent you a login link.</p>
+<h1>{% trans "Check Your Email" %}</h1>
+<p>{% trans "Thank you for signing up! We've sent you a login link." %}</p>
 {% endblock %}


### PR DESCRIPTION
## Summary
- enable i18n tags in templates
- translate navigation items and form labels
- add translation helpers in views and API
- mark default story title for translation

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_b_685fa3eecbe0832893da086440956be8