### PR TITLE
Fix missing LocaleMiddleware

### DIFF
--- a/taletinker/settings.py
+++ b/taletinker/settings.py
@@ -47,6 +47,7 @@ INSTALLED_APPS = [
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.locale.LocaleMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",


### PR DESCRIPTION
## Summary
- enable i18n by adding `LocaleMiddleware`

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_b_6860581cbe348328be1e0f059e546c7f