### PR TITLE
Update story list language handling

### DIFF
--- a/taletinker/stories/forms.py
+++ b/taletinker/stories/forms.py
@@ -113,12 +113,6 @@ class StoryFilterForm(forms.Form):
         label=_("Theme"),
     )
 
-    language = forms.ChoiceField(
-        choices=[("", _("Any Language"))] + settings.LANGUAGES,
-        required=False,
-        widget=forms.Select(attrs={"class": "form-select"}),
-        label=_("Language"),
-    )
 
     sort = forms.ChoiceField(
         choices=[("newest", _("Newest")), ("popular", _("Most Liked"))],

--- a/taletinker/stories/tests.py
+++ b/taletinker/stories/tests.py
@@ -210,13 +210,15 @@ class StoryListAndDetailTests(TestCase):
         self.assertIn("Fam", titles)
         self.assertNotIn("Ani", titles)
 
-    def test_filter_by_language(self):
+    def test_stories_use_request_language(self):
+        from django.utils.translation import override
+
         self._create_story(title="EN", published=True, languages=["en"])
         self._create_story(title="ES", published=True, languages=["es"])
 
-        resp = self.client.get(reverse("story_list") + "?language=es")
-        self.assertContains(resp, "ES")
-        self.assertNotContains(resp, "EN")
+        resp = self.client.get(reverse("story_list"), HTTP_ACCEPT_LANGUAGE="es")
+
+        self.assertEqual(resp.context["selected_language"], "es")
 
     def test_titles_use_selected_language(self):
         story = Story.objects.create(

--- a/taletinker/stories/views.py
+++ b/taletinker/stories/views.py
@@ -18,6 +18,7 @@ def _filtered_stories(request):
     cache_key = (
         f"story_list:"
         f"{request.user.id if request.user.is_authenticated else 'anon'}:"
+        f"{get_language()}:"
         f"{request.GET.urlencode()}"
     )
     stories = cache.get(cache_key)
@@ -25,7 +26,7 @@ def _filtered_stories(request):
     if stories is None:
         stories_qs = Story.objects.filter(is_published=True).prefetch_related(
             "texts", "author", "images"
-        )
+        ).filter(texts__language=get_language())
 
         filter_param = request.GET.get("filter")
         if filter_param == "mine" and request.user.is_authenticated:
@@ -36,14 +37,11 @@ def _filtered_stories(request):
         if form.is_valid():
             age = form.cleaned_data.get("age")
             theme = form.cleaned_data.get("theme")
-            language = form.cleaned_data.get("language")
             sort = form.cleaned_data.get("sort") or "newest"
             search = form.cleaned_data.get("search")
 
             if age:
                 stories_qs = stories_qs.filter(parameters__age=int(age))
-            if language:
-                stories_qs = stories_qs.filter(texts__language=language)
             if search:
                 stories_qs = stories_qs.filter(texts__title__icontains=search).distinct()
 
@@ -79,19 +77,17 @@ def story_list(request):
     page_obj = paginator.get_page(page_number)
     stories_page = list(page_obj.object_list)
 
-    selected_language = request.GET.get("lang")
+    selected_language = request.GET.get("lang") or get_language()
 
     for story in stories_page:
-        lang = selected_language or (
-            story.texts.first().language if story.texts.exists() else None
-        )
+        lang = selected_language
+        text_obj = story.texts.filter(language=lang).first()
+        if not text_obj:
+            text_obj = story.texts.first()
+            lang = text_obj.language if text_obj else None
         story.display_language = lang
-        if lang:
-            story.display_audio = story.audios.filter(language=lang).first()
-            story.display_text = story.texts.filter(language=lang).first()
-        else:
-            story.display_audio = None
-            story.display_text = story.texts.first()
+        story.display_text = text_obj
+        story.display_audio = story.audios.filter(language=lang).first() if lang else None
 
     playlist = None
     if request.user.is_authenticated:
@@ -103,16 +99,14 @@ def story_list(request):
             ordering = {sid: idx for idx, sid in enumerate(playlist.order)}
             playlist_stories.sort(key=lambda s: ordering.get(s.id, len(ordering)))
         for item in playlist_stories:
-            lang = selected_language or (
-                item.texts.first().language if item.texts.exists() else None
-            )
+            lang = selected_language
+            text_obj = item.texts.filter(language=lang).first()
+            if not text_obj:
+                text_obj = item.texts.first()
+                lang = text_obj.language if text_obj else None
             item.display_language = lang
-            if lang:
-                item.display_audio = item.audios.filter(language=lang).first()
-                item.display_text = item.texts.filter(language=lang).first()
-            else:
-                item.display_audio = None
-                item.display_text = item.texts.first()
+            item.display_text = text_obj
+            item.display_audio = item.audios.filter(language=lang).first() if lang else None
     else:
         playlist_stories = []
 


### PR DESCRIPTION
## Summary
- drop language filter from forms
- apply current language in `_filtered_stories` cache key and query
- default to request language for displaying stories and playlist items
- update tests to expect automatic language selection

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_b_68612ad0a6d4832891aaa724fe732e63