### PR TITLE
Update language handling for story views

### DIFF
--- a/taletinker/stories/views.py
+++ b/taletinker/stories/views.py
@@ -26,7 +26,7 @@ def _filtered_stories(request):
     if stories is None:
         stories_qs = Story.objects.filter(is_published=True).prefetch_related(
             "texts", "author", "images"
-        ).filter(texts__language=get_language())
+        )
 
         filter_param = request.GET.get("filter")
         if filter_param == "mine" and request.user.is_authenticated:
@@ -176,11 +176,9 @@ def create_story(request):
 def story_detail(request, story_uuid: str):
     story = get_object_or_404(Story, uuid=story_uuid)
 
-    lang = request.GET.get("lang")
-    text_obj = None
-    if lang:
-        text_obj = story.texts.filter(language=lang).first()
-    else:
+    lang = request.GET.get("lang") or get_language()
+    text_obj = story.texts.filter(language=lang).first()
+    if not text_obj:
         text_obj = story.texts.first()
         lang = text_obj.language if text_obj else None
 


### PR DESCRIPTION
## Summary
- keep stories regardless of translation availability
- default story detail to the active language

## Testing
- `pre-commit run --all-files` *(fails: .pre-commit-config.yaml is not a file)*
- `python manage.py test` *(fails: ImproperlyConfigured: Setting RECAPTCHA_PRIVATE_KEY is not of type str)*

------
https://chatgpt.com/codex/tasks/task_b_686130c658a08328a89fa73a83803191