### PR TITLE
Enable JS translations for create story page

### DIFF
--- a/taletinker/stories/templates/stories/create_story.html
+++ b/taletinker/stories/templates/stories/create_story.html
@@ -19,6 +19,8 @@
 
 </style>
 
+<script src="{% url 'javascript-catalog' %}"></script>
+
 <script>
 document.addEventListener('DOMContentLoaded', () => {
 
@@ -36,14 +38,29 @@ document.querySelectorAll('.chip').forEach(chip=>{
 /* ───── 3. RANDOM IDEA GENERATOR ───── */
 const ideaBtn = document.getElementById('random-idea-btn');
 if (ideaBtn) {
-    const adjectives = ['Silly','Brave','Curious','Sleepy','Hungry','Zippy'];
-    const creatures  = ['Dragon','Robot','Wizard','Panda','Unicorn','Spark','Noodle'];
+    const adjectives = [
+        gettext('Silly'),
+        gettext('Brave'),
+        gettext('Curious'),
+        gettext('Sleepy'),
+        gettext('Hungry'),
+        gettext('Zippy')
+    ];
+    const creatures  = [
+        gettext('Dragon'),
+        gettext('Robot'),
+        gettext('Wizard'),
+        gettext('Panda'),
+        gettext('Unicorn'),
+        gettext('Spark'),
+        gettext('Noodle')
+    ];
     const actions    = [
-        'finds a lost treasure',
-        'learns to dance',
-        'builds a sandcastle',
-        'joins a circus',
-        'flies to the moon'
+        gettext('finds a lost treasure'),
+        gettext('learns to dance'),
+        gettext('builds a sandcastle'),
+        gettext('joins a circus'),
+        gettext('flies to the moon')
     ];
     function pick(list){ return list[Math.floor(Math.random()*list.length)]; }
     ideaBtn.addEventListener('click',()=>{

--- a/taletinker/urls.py
+++ b/taletinker/urls.py
@@ -1,5 +1,6 @@
 from django.contrib import admin
 from django.urls import path, include
+from django.views.i18n import JavaScriptCatalog
 from sesame.views import LoginView as SesameLoginView
 from django.conf import settings
 from django.conf.urls.static import static
@@ -35,6 +36,7 @@ urlpatterns = [
     path('playlist/play/', play_playlist, name='play_playlist'),
     path('rss/<str:language>/', LatestStoriesByLanguage(), name='story_feed'),
     path('i18n/', include('django.conf.urls.i18n')),
+    path('jsi18n/', JavaScriptCatalog.as_view(), name='javascript-catalog'),
     path('api/', ninja_api.urls),
     path('search/', filter_stories, name='filter_stories'),
     path('', story_list, name='story_list'),


### PR DESCRIPTION
## Summary
- load JavaScript translation catalog in create_story.html
- mark random idea generator strings for translation using `gettext`
- expose `javascript-catalog` view in URLs

## Testing
- `python manage.py check`

------
https://chatgpt.com/codex/tasks/task_b_686106f7d648832881bfe75287ff4992