### PR TITLE
Restore auto-translation prompt

### DIFF
--- a/taletinker/stories/views.py
+++ b/taletinker/stories/views.py
@@ -178,9 +178,6 @@ def story_detail(request, story_uuid: str):
 
     lang = request.GET.get("lang") or get_language()
     text_obj = story.texts.filter(language=lang).first()
-    if not text_obj:
-        text_obj = story.texts.first()
-        lang = text_obj.language if text_obj else None
 
     audio_obj = story.audios.filter(language=lang).first() if lang else None
 


### PR DESCRIPTION
## Summary
- trigger translation when selected language text is missing

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_b_686133ba20948328b01c8332f5403eef